### PR TITLE
Refactored the code in style.css to remove repetitive lines of code for smooth scroll functionality

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,12 +14,8 @@
 }
 ::selection{
     color: red;
-    scroll-behavior: smooth;
 }
 
-html {
-    scroll-behavior: smooth;
-  }
 
 body{
     font-family: 'Poppins', sans-serif;


### PR DESCRIPTION
The property `scroll-behavior: smooth;` was defined unnecessarily twice, hence refactored the code to remove 'em.